### PR TITLE
Prevent submit whenever user captures  from webcam

### DIFF
--- a/WebcamShoot.php
+++ b/WebcamShoot.php
@@ -146,7 +146,7 @@ JS;
     </div>
     <div class="row">
         <div class="col-md-12 col-lg-12">
-                <button id="yii2-webcam-shoot-capture" class="btn btn-warning btn-block">{$this->buttonCaptureText}</button>
+                <button type="button" id="yii2-webcam-shoot-capture" class="btn btn-warning btn-block">{$this->buttonCaptureText}</button>
         </div>
     </div>
 HTML;


### PR DESCRIPTION
The form automatically submits whenever the user press capture. 
Add type='button' for  capture button to prevent submittion